### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 dgl-cu101==0.5.3
 embeddings==0.0.8
 transformers==3.5.1
-stanza==1.1.1
+stanza==1.2.3
 nltk==3.5


### PR DESCRIPTION
The stanza version 1.1.1 does not match the current resources.
When run_preprocess.sh is executed, an error like "Missing key(s) in state_dict" will appear.
The stanza package should be updated to the latest version.